### PR TITLE
Undo change of `dist` path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = (env) => {
         __dirname,
         isProduction ? "public/dist" : "dev-server/dist"
       ),
-      publicPath: "/dist/",
+      publicPath: "./dist/",
     },
     resolve: {
       // Add `.ts` and `.tsx` as a resolvable extension.


### PR DESCRIPTION
Was changed in 9a9bcb6874f47d2c7aeeedd297fef992e191e1f2, but caused
issue #106. This is a workaround for that.