### PR TITLE
Revert "Make dependabot daily"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily" # Testing auto-automerge
+      interval: "monthly"


### PR DESCRIPTION
This reverts commit 729b0245359e0e20064b3107a1b135365287bc3f.

Reason: Confirmed that automerge works correctly
(79622b2914c06eaff02631e66f1536ab710a6851).